### PR TITLE
Added -p parameter to allow user to specify terminator profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For more usage information you can consult the help:
 ```
 ./csshnator --help
 
-usage: csshnator [-h] [-l LOGIN] [-c CLUSTER_NAME]
+usage: csshnator [-h] [-l LOGIN] [-p PROFILE] [-s] [-c CLUSTER_NAME]
                  [cluster_nodes [cluster_nodes ...]]
 
 Open ClusterSSH-like session on Terminator

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ optional arguments:
   -h, --help            show this help message and exit
   -l LOGIN, --login LOGIN
                         Login username to pass to all hosts used.
+  -p PROFILE, --profile PROFILE
+                        Profile to use in terminator
   -c CLUSTER_NAME, --cluster-name CLUSTER_NAME
                         Cluster name is a collection of hosts available on
                         ~/.csshnatorrc file

--- a/csshnator
+++ b/csshnator
@@ -36,6 +36,15 @@ def parse_args(argv):
     )
 
     parser.add_argument(
+        '-p',
+        '--profile',
+        dest='profile',
+        type=str,
+        default="default",
+        help='Profile to use in terminator'
+    )
+
+    parser.add_argument(
         '-s',
         '--show',
         dest='show',
@@ -76,6 +85,7 @@ def main(argv):
         exit()
 
     cluster_name, login = args.cluster_name, args.login
+    profile = args.profile
 
     width = gtk.gdk.screen_width()
     height = gtk.gdk.screen_height()
@@ -189,7 +199,7 @@ def main(argv):
             term = term_name + str(row) + str(col)
             cssh_layout[term] = {
                 "command": command,
-                "profile": "default",
+                "profile": profile,
                 "type": "Terminal",
                 "order": order,
                 "parent": termparent,


### PR DESCRIPTION
I wanted to use a non default profile for my csshnator'ed window, but I had to select to it for each terminal.  This patch allows the user to speficy a profile other than default to be loaded by all terminals.